### PR TITLE
Retrieve real performance timing

### DIFF
--- a/src/CCapture.js
+++ b/src/CCapture.js
@@ -921,12 +921,24 @@ function CCapture( settings ) {
 
     }
 
+	function _getTiming() {
+
+		return {
+			framecount: _frameCount,
+			intermediateframecount: _intermediateFrameCount,
+			time: _time,
+			performancetime: _performanceTime
+		};
+
+	}
+
 	return {
 		start: _start,
 		capture: _capture,
 		stop: _stop,
 		save: _save,
-        on: _on
+		on: _on,
+		getTiming: _getTiming
 	}
 }
 


### PR DESCRIPTION
This is to support tweaking the playback of video textures as reported in #20 . I know you had a different idea but I've not been able to figure out how to do what you mean.

So my code in the `animate()` loop looks a bit like:

```
var recoding_fps = 60;
timing = capturer.getTiming();
actual_fps = timing.performancetime - lasttiming.performancetime;
ratio = actual_fps / recording_fps;
// playbackRate is normalised
video.playbackRate = ratio;
```