### PR TITLE
Don't set currentTime if it's already defined.

### DIFF
--- a/src/CCapture.js
+++ b/src/CCapture.js
@@ -716,8 +716,12 @@ function CCapture( settings ) {
 			return this._hookedTime + _settings.startTime;
 		};
 
-		Object.defineProperty( HTMLVideoElement.prototype, 'currentTime', { get: hookCurrentTime } )
-		Object.defineProperty( HTMLAudioElement.prototype, 'currentTime', { get: hookCurrentTime } )
+		try {
+			Object.defineProperty( HTMLVideoElement.prototype, 'currentTime', { get: hookCurrentTime } )
+			Object.defineProperty( HTMLAudioElement.prototype, 'currentTime', { get: hookCurrentTime } )
+		} catch (err) {
+			_log(err);
+		}
 
 	}
 	


### PR DESCRIPTION
Handling this exception allows ccapture to be stopped _and then restarted_.