### PR TITLE
Add examples and assets to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+examples
+assets


### PR DESCRIPTION
I installed the npm module on a slow connection and found out that the resulting directory is ~48MB compressed. The assets and examples are great but seem undesirable in `node_modules`. This PR adds both to `.npmignore`. Your call on merging, but it'd really be appreciated by at least one person! 🚀  Otherwise giving the module a try now… Thanks so much!