### PR TITLE
Update webm-writer-js to 0.2.4 to fix non-functional "quality" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Include CCapture[.min].js and [WebM Writer](https://github.com/thenickdude/webm-
 ```html
 <script src="CCapture.min.js"></script>
 <!-- Include WebM Writer if you want to export WebM -->
-<script src="webm-writer-0.2.0.js"></script>
+<script src="webm-writer-0.2.4.js"></script>
 <!-- Include gifjs if you want to export GIF -->
 <script src="gif.js"></script>
 <!-- Include tar.js if you want to export PNG or JPEG -->

--- a/utils/build.sh
+++ b/utils/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 uglifyjs ../src/CCapture.js --compress --mangle -o ../build/CCapture.min.js
-uglifyjs ../src/webm-writer-0.2.0.js ../src/download.js ../src/tar.js ../src/gif.js ../src/CCapture.js --compress --mangle -o ../build/CCapture.all.min.js
+uglifyjs ../src/webm-writer-0.2.4.js ../src/download.js ../src/tar.js ../src/gif.js ../src/CCapture.js --compress --mangle -o ../build/CCapture.all.min.js


### PR DESCRIPTION
Version 0.2.0 of webm-writer-js didn't pass the quality parameter properly to the browser, which rendered it non-functional. This PR updates to 0.2.4 which fixes that issue.

( https://github.com/thenickdude/webm-writer-js/issues/9 )