### PR TITLE
CCapture.all.min.js and gif.worker.js file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Include CCapture[.min].js and [WebM Writer](https://github.com/thenickdude/webm-
 <!-- Include download.js for easier file download -->
 <script src="download.js"></script>
 ```
-Or include the whole pack
+Or include the whole pack : /build/CCapture.all.min.js
 ```html
 <script src="CCapture.all.min.js"></script>
 ```
@@ -78,7 +78,7 @@ To create a CCapture object, write:
 var capturer = new CCapture( { format: 'webm' } );
 
 // Create a capturer that exports an animated GIF
-// Notices you have to specify the path to the gif.worker.js 
+// Notices you have to specify the path to the gif.worker.js : /src/gif.worker.js
 var capturer = new CCapture( { format: 'gif', workersPath: 'js/' } );
 
 // Create a capturer that exports PNG images in a TAR file


### PR DESCRIPTION
As a beginner to the project, It seems confusions , where to find this CCapture.all.min.js and gif.worker.js file(is it available in this repo or not?). To mention the location of these files too, in the document, with it, is required and necessary too. I wanted to start with this , but got confused with documentation that, the dependencies of scripts, it is talking about (especially gif.worker.js) , where I will find that? but later, I found it is available in src folder (but took my time).
To solve this issue for any other like me, I am creating this pull request to update the location of these files in README.